### PR TITLE
Update the model.json URL in the example

### DIFF
--- a/examples/bert-sentiment-analysis/flow.json
+++ b/examples/bert-sentiment-analysis/flow.json
@@ -285,7 +285,7 @@
     "id": "ac34574f.b32b08",
     "type": "tf-model",
     "z": "3b8fa5ec.1fd73a",
-    "modelURL": "https://max-cdn.cdn.appdomain.cloud/max-text-sentiment-classifier/tfjs/0.1.0/model.json",
+    "modelURL": "https://bert-sentiment.s3.us.cloud-object-storage.appdomain.cloud/model/model.json",
     "outputNode": "loss/Softmax",
     "name": "BERT Sentiment Model",
     "x": 150,


### PR DESCRIPTION
The old URL stopped working and hence the example was not working. Hence, updating the URL to a new URL (which I found in IBM article) here. After that, I tested the example again and it started working.